### PR TITLE
rev 1.4: Make tristate ports top-level

### DIFF
--- a/quabo_master/ip_repo/wr-cores-Quabo/component.xml
+++ b/quabo_master/ip_repo/wr-cores-Quabo/component.xml
@@ -2225,6 +2225,7 @@
     <xilinx:coreExtensions>
       <xilinx:supportedFamilies>
         <xilinx:family xilinx:lifeCycle="Production">kintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">zynq</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
         <xilinx:taxonomy>/UserIP</xilinx:taxonomy>

--- a/quabo_master/ip_repo/wr-cores-Quabo/component.xml
+++ b/quabo_master/ip_repo/wr-cores-Quabo/component.xml
@@ -3,7 +3,7 @@
   <spirit:vendor>user.org</spirit:vendor>
   <spirit:library>user</spirit:library>
   <spirit:name>wrc_board_quabo_Light</spirit:name>
-  <spirit:version>1.3</spirit:version>
+  <spirit:version>1.4</spirit:version>
   <spirit:busInterfaces>
     <spirit:busInterface>
       <spirit:name>sfp</spirit:name>
@@ -53,22 +53,6 @@
         </spirit:portMap>
         <spirit:portMap>
           <spirit:logicalPort>
-            <spirit:name>sfp_mod_def1_b</spirit:name>
-          </spirit:logicalPort>
-          <spirit:physicalPort>
-            <spirit:name>sfp_mod_def1_b</spirit:name>
-          </spirit:physicalPort>
-        </spirit:portMap>
-        <spirit:portMap>
-          <spirit:logicalPort>
-            <spirit:name>sfp_mod_def2_b</spirit:name>
-          </spirit:logicalPort>
-          <spirit:physicalPort>
-            <spirit:name>sfp_mod_def2_b</spirit:name>
-          </spirit:physicalPort>
-        </spirit:portMap>
-        <spirit:portMap>
-          <spirit:logicalPort>
             <spirit:name>sfp_rate_select_o</spirit:name>
           </spirit:logicalPort>
           <spirit:physicalPort>
@@ -97,6 +81,54 @@
           </spirit:logicalPort>
           <spirit:physicalPort>
             <spirit:name>sfp_los_i</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def1_t_o</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def1_t_o</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def2_i</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def2_i</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def2_t_o</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def2_t_o</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def1_i</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def1_i</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def2_o</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def2_o</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>sfp_mod_def1_o</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>sfp_mod_def1_o</spirit:name>
           </spirit:physicalPort>
         </spirit:portMap>
       </spirit:portMaps>
@@ -126,7 +158,7 @@
       </spirit:portMaps>
     </spirit:busInterface>
     <spirit:busInterface>
-      <spirit:name>reset_i</spirit:name>
+      <spirit:name>reset_n_i</spirit:name>
       <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="reset" spirit:version="1.0"/>
       <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="reset_rtl" spirit:version="1.0"/>
       <spirit:slave/>
@@ -136,7 +168,7 @@
             <spirit:name>RST</spirit:name>
           </spirit:logicalPort>
           <spirit:physicalPort>
-            <spirit:name>reset_i</spirit:name>
+            <spirit:name>reset_n_i</spirit:name>
           </spirit:physicalPort>
         </spirit:portMap>
       </spirit:portMaps>
@@ -196,7 +228,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>0073c606</spirit:value>
+            <spirit:value>e14c4166</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -212,7 +244,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>0073c606</spirit:value>
+            <spirit:value>e14c4166</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -404,9 +436,9 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>sfp_mod_def1_b</spirit:name>
+        <spirit:name>sfp_mod_def1_i</spirit:name>
         <spirit:wire>
-          <spirit:direction>inout</spirit:direction>
+          <spirit:direction>in</spirit:direction>
           <spirit:wireTypeDefs>
             <spirit:wireTypeDef>
               <spirit:typeName>std_logic</spirit:typeName>
@@ -417,9 +449,61 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>sfp_mod_def2_b</spirit:name>
+        <spirit:name>sfp_mod_def1_o</spirit:name>
         <spirit:wire>
-          <spirit:direction>inout</spirit:direction>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>sfp_mod_def1_t_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>sfp_mod_def2_i</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>sfp_mod_def2_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>sfp_mod_def2_t_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
           <spirit:wireTypeDefs>
             <spirit:wireTypeDef>
               <spirit:typeName>std_logic</spirit:typeName>
@@ -482,9 +566,35 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>onewire_b</spirit:name>
+        <spirit:name>onewire_i</spirit:name>
         <spirit:wire>
-          <spirit:direction>inout</spirit:direction>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>onewire_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>onewire_t_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
           <spirit:wireTypeDefs>
             <spirit:wireTypeDef>
               <spirit:typeName>std_logic</spirit:typeName>
@@ -573,7 +683,7 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
-        <spirit:name>reset_i</spirit:name>
+        <spirit:name>reset_n_i</spirit:name>
         <spirit:wire>
           <spirit:direction>in</spirit:direction>
           <spirit:wireTypeDefs>
@@ -635,6 +745,32 @@
           <spirit:wireTypeDefs>
             <spirit:wireTypeDef>
               <spirit:typeName>std_logic_vector</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>led_act_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>led_link_o</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
               <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
               <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
             </spirit:wireTypeDef>
@@ -1350,7 +1486,7 @@
       <spirit:file>
         <spirit:name>board/quabo/wrc_board_quabo.vhd</spirit:name>
         <spirit:fileType>vhdlSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_26516673</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_e2b44083</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
@@ -2052,7 +2188,7 @@
     <spirit:fileSet>
       <spirit:name>xilinx_xpgui_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>xgui/wrc_board_quabo_Light_v1_3.tcl</spirit:name>
+        <spirit:name>xgui/wrc_board_quabo_Light_v1_4.tcl</spirit:name>
         <spirit:fileType>tclSource</spirit:fileType>
         <spirit:userFileType>CHECKSUM_c64e2842</spirit:userFileType>
         <spirit:userFileType>XGUI_VERSION_2</spirit:userFileType>
@@ -2068,7 +2204,7 @@
       </spirit:file>
     </spirit:fileSet>
   </spirit:fileSets>
-  <spirit:description>wrc_for_quabo_v1_3(wr_core_v4.2)</spirit:description>
+  <spirit:description>wrc_for_quabo(wr_core_v4.2)</spirit:description>
   <spirit:parameters>
     <spirit:parameter>
       <spirit:name>g_dpram_initf</spirit:name>
@@ -2093,14 +2229,15 @@
       <xilinx:taxonomies>
         <xilinx:taxonomy>/UserIP</xilinx:taxonomy>
       </xilinx:taxonomies>
-      <xilinx:displayName>wrc_for_quabo_v1_2</xilinx:displayName>
+      <xilinx:displayName>wrc_for_quabo</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
-      <xilinx:coreRevision>1</xilinx:coreRevision>
+      <xilinx:coreRevision>8</xilinx:coreRevision>
       <xilinx:upgrades>
         <xilinx:canUpgradeFrom>user.org:user:wrc_board_quabo_Light:1.1</xilinx:canUpgradeFrom>
         <xilinx:canUpgradeFrom>user.org:user:wrc_board_quabo_Light:1.2</xilinx:canUpgradeFrom>
+        <xilinx:canUpgradeFrom>user.org:user:wrc_board_quabo_Light:1.3</xilinx:canUpgradeFrom>
       </xilinx:upgrades>
-      <xilinx:coreCreationDateTime>2022-01-11T22:54:13Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-05-26T10:33:46Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@529e3652_ARCHIVE_LOCATION">/media/wei/DATA/LW/Project/WR_Project/WR_Reference_Design/wr-cores-acme1-vivado-Streamers-light/wr-cores-Quabo</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@7e6a5939_ARCHIVE_LOCATION">/media/wei/DATA/LW/Project/WR_Project/WR_Reference_Design/wr-cores-acme1-vivado-Streamers-light/wr-cores-Quabo</xilinx:tag>
@@ -2614,13 +2751,68 @@
         <xilinx:tag xilinx:name="ui.data.coregen.dd@194c5088_ARCHIVE_LOCATION">/data/home/weiliu/Projects/panoseti/V0200/tmp/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@2a74b245_ARCHIVE_LOCATION">/data/home/weiliu/Projects/panoseti/V0200/tmp/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@26f472ac_ARCHIVE_LOCATION">/data/home/weiliu/Projects/panoseti/V0200/tmp/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@17612369_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7dd41047_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@513efd71_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3fd41d87_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@22f45986_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6cb4225f_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5d54d90b_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@25fad5ec_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@708e825f_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@46813c43_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@25028c3b_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@176b4699_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@8ff92c2_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2f9970e8_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4b765433_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@41609ec8_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1d213c81_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@206235da_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@562d95f3_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@32dd2d6c_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@493ccbaf_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@300f89d7_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3570d931_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@417c00ef_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7de75435_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2424bce2_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@637629fd_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6e52e07b_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@903f6a9_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2fbeec88_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4afcc9ef_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@223eadef_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4285b64f_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3f2bdb79_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@27c5737e_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@77a88a51_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4b939da4_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5d131a6d_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@53c6bfc2_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@46ce6d47_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@61d869a8_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3875d161_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@271ee1a_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4fadaedf_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6fed9a3_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@75e1c122_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7b55e6db_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5a202a6b_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5ce773df_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1dc928e1_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@bed01de_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@505858be_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7560dedc_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@68dff953_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@58908a0_ARCHIVE_LOCATION">/home/jackh/src/cfa_digitizer/quabo_firmware/quabo_master/ip_repo/wr-cores-Quabo</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
-      <xilinx:xilinxVersion>2018.3</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="dd39bb1a"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="1977a9af"/>
-      <xilinx:checksum xilinx:scope="ports" xilinx:value="be7dd945"/>
+      <xilinx:xilinxVersion>2019.1.3</xilinx:xilinxVersion>
+      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="ea74520d"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="494d4134"/>
+      <xilinx:checksum xilinx:scope="ports" xilinx:value="45205fad"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="6029db69"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="7cc1b723"/>
     </xilinx:packagingInfo>

--- a/quabo_master/ip_repo/wr-cores-Quabo/flash_spi.xml
+++ b/quabo_master/ip_repo/wr-cores-Quabo/flash_spi.xml
@@ -2,7 +2,7 @@
 <spirit:busDefinition xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <spirit:vendor>user.org</spirit:vendor>
   <spirit:library>user</spirit:library>
-  <spirit:name>falsh_spi</spirit:name>
+  <spirit:name>flash_spi</spirit:name>
   <spirit:version>1.1</spirit:version>
   <spirit:directConnection>false</spirit:directConnection>
   <spirit:isAddressable>false</spirit:isAddressable>

--- a/quabo_master/ip_repo/wr-cores-Quabo/flash_spi_rtl.xml
+++ b/quabo_master/ip_repo/wr-cores-Quabo/flash_spi_rtl.xml
@@ -2,9 +2,9 @@
 <spirit:abstractionDefinition xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <spirit:vendor>user.org</spirit:vendor>
   <spirit:library>user</spirit:library>
-  <spirit:name>falsh_spi_rtl</spirit:name>
+  <spirit:name>flash_spi_rtl</spirit:name>
   <spirit:version>1.1</spirit:version>
-  <spirit:busType spirit:vendor="user.org" spirit:library="user" spirit:name="falsh_spi" spirit:version="1.1"/>
+  <spirit:busType spirit:vendor="user.org" spirit:library="user" spirit:name="flash_spi" spirit:version="1.1"/>
   <spirit:ports>
     <spirit:port>
       <spirit:logicalName>spi_ncs_o</spirit:logicalName>

--- a/quabo_master/ip_repo/wr-cores-Quabo/sfp_rtl.xml
+++ b/quabo_master/ip_repo/wr-cores-Quabo/sfp_rtl.xml
@@ -77,32 +77,86 @@
       </spirit:wire>
     </spirit:port>
     <spirit:port>
-      <spirit:logicalName>sfp_mod_def1_b</spirit:logicalName>
+      <spirit:logicalName>sfp_mod_def1_i</spirit:logicalName>
       <spirit:wire>
         <spirit:onMaster>
           <spirit:presence>required</spirit:presence>
           <spirit:width>1</spirit:width>
-          <spirit:direction>inout</spirit:direction>
+          <spirit:direction>in</spirit:direction>
         </spirit:onMaster>
         <spirit:onSlave>
           <spirit:presence>required</spirit:presence>
           <spirit:width>1</spirit:width>
-          <spirit:direction>inout</spirit:direction>
         </spirit:onSlave>
       </spirit:wire>
     </spirit:port>
     <spirit:port>
-      <spirit:logicalName>sfp_mod_def2_b</spirit:logicalName>
+      <spirit:logicalName>sfp_mod_def1_o</spirit:logicalName>
       <spirit:wire>
         <spirit:onMaster>
           <spirit:presence>required</spirit:presence>
           <spirit:width>1</spirit:width>
-          <spirit:direction>inout</spirit:direction>
+          <spirit:direction>out</spirit:direction>
         </spirit:onMaster>
         <spirit:onSlave>
           <spirit:presence>required</spirit:presence>
           <spirit:width>1</spirit:width>
-          <spirit:direction>inout</spirit:direction>
+        </spirit:onSlave>
+      </spirit:wire>
+    </spirit:port>
+    <spirit:port>
+      <spirit:logicalName>sfp_mod_def1_t_o</spirit:logicalName>
+      <spirit:wire>
+        <spirit:onMaster>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+          <spirit:direction>out</spirit:direction>
+        </spirit:onMaster>
+        <spirit:onSlave>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+        </spirit:onSlave>
+      </spirit:wire>
+    </spirit:port>
+    <spirit:port>
+      <spirit:logicalName>sfp_mod_def2_i</spirit:logicalName>
+      <spirit:wire>
+        <spirit:onMaster>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+          <spirit:direction>in</spirit:direction>
+        </spirit:onMaster>
+        <spirit:onSlave>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+        </spirit:onSlave>
+      </spirit:wire>
+    </spirit:port>
+    <spirit:port>
+      <spirit:logicalName>sfp_mod_def2_o</spirit:logicalName>
+      <spirit:wire>
+        <spirit:onMaster>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+          <spirit:direction>out</spirit:direction>
+        </spirit:onMaster>
+        <spirit:onSlave>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+        </spirit:onSlave>
+      </spirit:wire>
+    </spirit:port>
+    <spirit:port>
+      <spirit:logicalName>sfp_mod_def2_t_o</spirit:logicalName>
+      <spirit:wire>
+        <spirit:onMaster>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
+          <spirit:direction>out</spirit:direction>
+        </spirit:onMaster>
+        <spirit:onSlave>
+          <spirit:presence>required</spirit:presence>
+          <spirit:width>1</spirit:width>
         </spirit:onSlave>
       </spirit:wire>
     </spirit:port>

--- a/quabo_master/ip_repo/wr-cores-Quabo/xgui/wrc_board_quabo_Light_v1_4.tcl
+++ b/quabo_master/ip_repo/wr-cores-Quabo/xgui/wrc_board_quabo_Light_v1_4.tcl
@@ -1,0 +1,40 @@
+# Definitional proc to organize widgets for parameters.
+proc init_gui { IPINST } {
+  ipgui::add_param $IPINST -name "Component_Name"
+  #Adding Page
+  set Page_0 [ipgui::add_page $IPINST -name "Page 0"]
+  ipgui::add_param $IPINST -name "g_dpram_initf" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "g_simulation" -parent ${Page_0}
+
+
+}
+
+proc update_PARAM_VALUE.g_dpram_initf { PARAM_VALUE.g_dpram_initf } {
+	# Procedure called to update g_dpram_initf when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.g_dpram_initf { PARAM_VALUE.g_dpram_initf } {
+	# Procedure called to validate g_dpram_initf
+	return true
+}
+
+proc update_PARAM_VALUE.g_simulation { PARAM_VALUE.g_simulation } {
+	# Procedure called to update g_simulation when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.g_simulation { PARAM_VALUE.g_simulation } {
+	# Procedure called to validate g_simulation
+	return true
+}
+
+
+proc update_MODELPARAM_VALUE.g_dpram_initf { MODELPARAM_VALUE.g_dpram_initf PARAM_VALUE.g_dpram_initf } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.g_dpram_initf}] ${MODELPARAM_VALUE.g_dpram_initf}
+}
+
+proc update_MODELPARAM_VALUE.g_simulation { MODELPARAM_VALUE.g_simulation PARAM_VALUE.g_simulation } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.g_simulation}] ${MODELPARAM_VALUE.g_simulation}
+}
+


### PR DESCRIPTION
- Break out I/O/T ports to top level, to prevent an issue
  where Xilinx won't infer tristate buffers for bidirectional
  ports into out-of-context compiled IP.
- Expose ethernet Link/activity LEDs